### PR TITLE
T-025: Normalize DWZ spend across Banner, Bridge, and Chart (scale-invariant depletion)

### DIFF
--- a/src/components/GlobalBanner.jsx
+++ b/src/components/GlobalBanner.jsx
@@ -54,7 +54,8 @@ export function GlobalBanner({ decision, lifeExpectancy, bequest = 0 }) {
 
   if (isViable) {
     // Green message: fully viable retirement
-    const desiredSpend = formatMoney(decisionKpis.sustainableAnnual || decisionKpis.planSpend || 0);
+    // T-025: Use unified DWZ sustainableAnnual
+    const desiredSpend = formatMoney(dwz?.sustainableAnnual || decisionKpis.sustainableAnnual || decisionKpis.planSpend || 0);
     mainMessage = (
       <>
         🎯 You can retire at age <strong>{earliestFireAge}</strong> with Die-With-Zero
@@ -65,13 +66,14 @@ export function GlobalBanner({ decision, lifeExpectancy, bequest = 0 }) {
         Sustainable spending: <strong>${desiredSpend}/yr</strong> (L={lifeExpectancy}, Bequest=${formatMoney(bequest)})
       </>
     );
-  } else if (decisionKpis?.earliestTheoreticalAge) {
+  } else if (decisionKpis?.earliestTheoreticalAge || dwz?.earliestTheoreticalAge) {
     // Amber message: theoretical age exists but bridge constraint fails
-    const theoreticalAge = decisionKpis.earliestTheoreticalAge;
+    const theoreticalAge = dwz?.earliestTheoreticalAge || decisionKpis.earliestTheoreticalAge;
+    // T-025: Use unified bridge fields
     const shortfall = bridge.shortfall || 0;
     const years = bridge.years || 0;
-    const need = bridge.need || 0;
-    const have = bridge.have || 0;
+    const need = bridge.needTotal || bridge.need || 0;
+    const have = bridge.haveTotal || bridge.have || 0;
     
     mainMessage = (
       <>

--- a/tests/dwz-consistency.test.js
+++ b/tests/dwz-consistency.test.js
@@ -1,0 +1,277 @@
+import { describe, it, expect } from 'vitest';
+import { decisionFromState } from '../src/selectors/decision.js';
+import { bandMultiplierAt, computeBridgeFromSchedule } from '../src/core/age_bands.js';
+import auRules from '../src/data/au_rules.json';
+
+describe('T-025: DWZ Consistency and Scale Invariance', () => {
+  describe('Scale Invariance', () => {
+    const baseState = {
+      currentAge: 35,
+      retirementAge: 50,
+      lifeExpectancy: 85,
+      currentSavings: 200000,
+      currentSuper: 300000,
+      annualIncome: 100000,
+      annualExpenses: 60000,
+      expectedReturn: 7.0,
+      inflationRate: 2.5,
+      planningAs: 'single',
+      ageBandsEnabled: true,
+      bequest: 0
+    };
+
+    it('should maintain consistency when balances are scaled 10x', () => {
+      // Base scenario
+      const baseDecision = decisionFromState(baseState, auRules);
+      
+      // 10x scaled scenario
+      const scaledState = {
+        ...baseState,
+        currentSavings: baseState.currentSavings * 10,
+        currentSuper: baseState.currentSuper * 10
+      };
+      const scaledDecision = decisionFromState(scaledState, auRules);
+
+      // Both should have valid DWZ bundles
+      expect(baseDecision.dwz).toBeDefined();
+      expect(scaledDecision.dwz).toBeDefined();
+      
+      // Path should end within ±1% of bequest target for both
+      if (baseDecision.dwz?.path?.length > 0) {
+        const baseFinalPoint = baseDecision.dwz.path[baseDecision.dwz.path.length - 1];
+        const tolerance = Math.max(1, 0.01 * baseDecision.dwz.sustainableAnnual);
+        expect(Math.abs(baseFinalPoint.total - baseState.bequest)).toBeLessThanOrEqual(tolerance);
+      }
+
+      if (scaledDecision.dwz?.path?.length > 0) {
+        const scaledFinalPoint = scaledDecision.dwz.path[scaledDecision.dwz.path.length - 1];
+        const tolerance = Math.max(1, 0.01 * scaledDecision.dwz.sustainableAnnual);
+        expect(Math.abs(scaledFinalPoint.total - baseState.bequest)).toBeLessThanOrEqual(tolerance);
+      }
+
+      // Bridge calculation should scale appropriately
+      if (baseDecision.dwz?.bridge && scaledDecision.dwz?.bridge) {
+        // Bridge years should be the same
+        expect(scaledDecision.dwz.bridge.years).toBe(baseDecision.dwz.bridge.years);
+        
+        // Scaled scenario should either have same coverage or better coverage
+        if (baseDecision.dwz.bridge.isCovered) {
+          expect(scaledDecision.dwz.bridge.isCovered).toBe(true);
+        }
+      }
+    });
+
+    it('should show declining wealth trajectory regardless of scale', () => {
+      const states = [
+        baseState,
+        { ...baseState, currentSavings: baseState.currentSavings * 10, currentSuper: baseState.currentSuper * 10 }
+      ];
+
+      states.forEach((state, index) => {
+        const decision = decisionFromState(state, auRules);
+        
+        if (decision.dwz?.isViable && decision.dwz?.path?.length > 10) {
+          const retirementAge = decision.dwz.earliestViableAge || 60;
+          const retirementIndex = decision.dwz.path.findIndex(p => p.age >= retirementAge);
+          
+          if (retirementIndex > 0 && retirementIndex < decision.dwz.path.length - 10) {
+            // Check that wealth eventually declines after retirement
+            const midIndex = Math.floor((retirementIndex + decision.dwz.path.length) / 2);
+            const endIndex = decision.dwz.path.length - 1;
+            
+            const retirementWealth = decision.dwz.path[retirementIndex].total;
+            const midWealth = decision.dwz.path[midIndex].total;
+            const endWealth = decision.dwz.path[endIndex].total;
+            
+            // Should show decline from retirement to end
+            expect(endWealth).toBeLessThan(retirementWealth);
+            
+            // Test name for debugging
+            console.log(`Scale ${index === 0 ? '1x' : '10x'}: Retirement=${retirementWealth}, Mid=${midWealth}, End=${endWealth}`);
+          }
+        }
+      });
+    });
+  });
+
+  describe('Banner-Bridge Consistency', () => {
+    it('should never show green banner with red bridge status', () => {
+      const testStates = [
+        // High balance scenario (should be green/covered)
+        {
+          currentAge: 40,
+          retirementAge: 55,
+          lifeExpectancy: 85,
+          currentSavings: 800000,
+          currentSuper: 1200000,
+          annualIncome: 120000,
+          annualExpenses: 70000,
+          expectedReturn: 7.0,
+          inflationRate: 2.5,
+          planningAs: 'single',
+          ageBandsEnabled: true,
+          bequest: 0
+        },
+        // Low balance scenario (should be amber/short)
+        {
+          currentAge: 40,
+          retirementAge: 45,
+          lifeExpectancy: 85,
+          currentSavings: 50000,
+          currentSuper: 100000,
+          annualIncome: 80000,
+          annualExpenses: 60000,
+          expectedReturn: 7.0,
+          inflationRate: 2.5,
+          planningAs: 'single',
+          ageBandsEnabled: true,
+          bequest: 0
+        }
+      ];
+
+      testStates.forEach((state, index) => {
+        const decision = decisionFromState(state, auRules);
+        
+        // Check DWZ bundle exists
+        expect(decision.dwz).toBeDefined();
+        expect(decision.dwz.bridge).toBeDefined();
+        
+        const isViable = decision.dwz.isViable;
+        const bridgeCovered = decision.dwz.bridge.isCovered;
+        
+        // Banner and bridge must agree on viability
+        if (isViable) {
+          expect(bridgeCovered).toBe(true);
+        } else {
+          // If not viable, bridge should be the reason (for early retirement scenarios)
+          expect(bridgeCovered).toBe(false);
+        }
+        
+        console.log(`Test ${index}: Viable=${isViable}, Bridge=${bridgeCovered}`);
+      });
+    });
+  });
+
+  describe('Helper Functions', () => {
+    describe('bandMultiplierAt', () => {
+      const sampleBands = [
+        { startAge: 50, endAge: 60, multiplier: 1.1, name: 'go-go' },
+        { startAge: 60, endAge: 75, multiplier: 1.0, name: 'slow-go' },
+        { startAge: 75, endAge: 90, multiplier: 0.85, name: 'no-go' }
+      ];
+
+      it('should return correct multipliers for different ages', () => {
+        expect(bandMultiplierAt(55, sampleBands)).toBe(1.1);
+        expect(bandMultiplierAt(65, sampleBands)).toBe(1.0);
+        expect(bandMultiplierAt(80, sampleBands)).toBe(0.85);
+      });
+
+      it('should return default multiplier for ages outside bands', () => {
+        expect(bandMultiplierAt(45, sampleBands)).toBe(1); // before first band
+        expect(bandMultiplierAt(95, sampleBands)).toBe(1); // after last band
+      });
+
+      it('should handle empty or undefined bands', () => {
+        expect(bandMultiplierAt(55, [])).toBe(1);
+        expect(bandMultiplierAt(55, undefined)).toBe(1);
+        expect(bandMultiplierAt(55, null)).toBe(1);
+      });
+    });
+
+    describe('computeBridgeFromSchedule', () => {
+      const sampleBands = [
+        { startAge: 50, endAge: 60, multiplier: 1.1, name: 'go-go' },
+        { startAge: 60, endAge: 75, multiplier: 1.0, name: 'slow-go' }
+      ];
+
+      it('should compute bridge requirement using schedule-based spending', () => {
+        const result = computeBridgeFromSchedule({
+          startAge: 50,
+          S_base: 60000,
+          bands: sampleBands,
+          outsideAtRetire: 500000,
+          preservationAge: 60,
+          epsilon: 1
+        });
+
+        expect(result.years).toBe(10); // 50 to 60
+        expect(result.needTotal).toBe(60000 * 1.1 * 10); // S_base * go-go multiplier * years
+        expect(result.haveTotal).toBe(500000);
+        expect(result.isCovered).toBe(result.haveTotal >= result.needTotal - 1);
+      });
+
+      it('should return zero requirement when no bridge needed', () => {
+        const result = computeBridgeFromSchedule({
+          startAge: 65,
+          S_base: 60000,
+          bands: sampleBands,
+          outsideAtRetire: 500000,
+          preservationAge: 60,
+          epsilon: 1
+        });
+
+        expect(result.years).toBe(0);
+        expect(result.needTotal).toBe(0);
+        expect(result.isCovered).toBe(true);
+        expect(result.status).toBe('covered');
+      });
+
+      it('should apply epsilon clamp for nearly-covered scenarios', () => {
+        const result = computeBridgeFromSchedule({
+          startAge: 50,
+          S_base: 60000,
+          bands: sampleBands,
+          outsideAtRetire: 659999, // $1 short of 660,000 needed
+          preservationAge: 60,
+          epsilon: 1
+        });
+
+        expect(result.isCovered).toBe(true); // Should be covered due to epsilon
+        expect(result.shortfall).toBe(0); // Should be clamped to zero
+      });
+    });
+  });
+
+  describe('Insurance Premium Integration', () => {
+    it('should apply insurance premiums consistently in path and bridge', () => {
+      const stateWithInsurance = {
+        currentAge: 35,
+        retirementAge: 50,
+        lifeExpectancy: 85,
+        currentSavings: 300000,
+        currentSuper: 500000,
+        annualIncome: 100000,
+        annualExpenses: 60000,
+        expectedReturn: 7.0,
+        inflationRate: 2.5,
+        planningAs: 'single',
+        ageBandsEnabled: false, // Flat spending for simplicity
+        superInsurancePremium: 3000, // $3k annual premium
+        bequest: 0
+      };
+
+      const stateWithoutInsurance = {
+        ...stateWithInsurance,
+        superInsurancePremium: 0
+      };
+
+      const withInsurance = decisionFromState(stateWithInsurance, auRules);
+      const withoutInsurance = decisionFromState(stateWithoutInsurance, auRules);
+
+      // Both should have paths
+      expect(withInsurance.dwz?.path).toBeDefined();
+      expect(withoutInsurance.dwz?.path).toBeDefined();
+
+      if (withInsurance.dwz?.path?.length > 5 && withoutInsurance.dwz?.path?.length > 5) {
+        // Compare super balances at age 45 (before retirement)
+        const age45WithIns = withInsurance.dwz.path.find(p => p.age === 45);
+        const age45WithoutIns = withoutInsurance.dwz.path.find(p => p.age === 45);
+
+        if (age45WithIns && age45WithoutIns) {
+          // Super should be lower with insurance
+          expect(age45WithIns.super).toBeLessThan(age45WithoutIns.super);
+        }
+      }
+    });
+  });
+});

--- a/tests/dwz-depletion-path.test.js
+++ b/tests/dwz-depletion-path.test.js
@@ -1,0 +1,209 @@
+import { describe, it, expect } from 'vitest';
+import { buildDwzDepletionPath } from '../src/core/age_bands.js';
+import { decisionFromState } from '../src/selectors/decision.js';
+import auRules from '../src/data/au_rules.json';
+
+describe('T-024: DWZ Depletion Path Tests', () => {
+  describe('buildDwzDepletionPath', () => {
+    it('should end within ±1% of bequest at life expectancy', () => {
+      const path = buildDwzDepletionPath({
+        currentAge: 30,
+        retirementAge: 50,
+        lifeExpectancy: 85,
+        sustainableAnnual: 60000,
+        bands: [
+          { startAge: 50, endAge: 60, multiplier: 1.1, name: 'go-go' },
+          { startAge: 60, endAge: 75, multiplier: 1.0, name: 'slow-go' },
+          { startAge: 75, endAge: 85, multiplier: 0.85, name: 'no-go' }
+        ],
+        preservationAge: 60,
+        realReturn: 0.05,
+        fees: 0.005,
+        insurancePremium: 1000,
+        bequest: 0,
+        startBalances: { outside: 500000, super: 800000 }
+      });
+
+      const finalPoint = path[path.length - 1];
+      expect(finalPoint.age).toBe(85);
+      
+      // Should end close to bequest (0 for DWZ)
+      const tolerance = 0.01; // 1% tolerance
+      expect(Math.abs(finalPoint.total)).toBeLessThanOrEqual(tolerance * 1000); // Within $10 of $0
+    });
+
+    it('should draw from outside only during bridge period', () => {
+      const path = buildDwzDepletionPath({
+        currentAge: 30,
+        retirementAge: 45,
+        lifeExpectancy: 85,
+        sustainableAnnual: 50000,
+        bands: [{ startAge: 45, endAge: 85, multiplier: 1, name: 'flat' }],
+        preservationAge: 60,
+        realReturn: 0.05,
+        fees: 0,
+        insurancePremium: 0,
+        bequest: 0,
+        startBalances: { outside: 400000, super: 600000 }
+      });
+
+      // Find points during bridge period (45-60)
+      const bridgePoints = path.filter(p => p.age >= 45 && p.age < 60);
+      
+      // Outside should decrease during bridge
+      for (let i = 1; i < bridgePoints.length; i++) {
+        const prev = bridgePoints[i - 1];
+        const curr = bridgePoints[i];
+        
+        // Outside should decrease (after accounting for returns)
+        const expectedOutside = (prev.outside - 50000) * 1.05;
+        expect(curr.outside).toBeLessThanOrEqual(expectedOutside * 1.01); // Allow 1% tolerance
+        
+        // Super should only grow (no withdrawals)
+        expect(curr.super).toBeGreaterThanOrEqual(prev.super);
+      }
+    });
+
+    it('should apply insurance premiums to super balance', () => {
+      const pathWithInsurance = buildDwzDepletionPath({
+        currentAge: 30,
+        retirementAge: 50,
+        lifeExpectancy: 85,
+        sustainableAnnual: 60000,
+        bands: [{ startAge: 50, endAge: 85, multiplier: 1, name: 'flat' }],
+        preservationAge: 60,
+        realReturn: 0.05,
+        fees: 0,
+        insurancePremium: 2000, // $2k annual premium
+        bequest: 0,
+        startBalances: { outside: 500000, super: 800000 }
+      });
+
+      const pathNoInsurance = buildDwzDepletionPath({
+        currentAge: 30,
+        retirementAge: 50,
+        lifeExpectancy: 85,
+        sustainableAnnual: 60000,
+        bands: [{ startAge: 50, endAge: 85, multiplier: 1, name: 'flat' }],
+        preservationAge: 60,
+        realReturn: 0.05,
+        fees: 0,
+        insurancePremium: 0, // No insurance
+        bequest: 0,
+        startBalances: { outside: 500000, super: 800000 }
+      });
+
+      // Super balance should be lower with insurance at each age (except the first point which is starting balance)
+      for (let i = 1; i < Math.min(pathWithInsurance.length, pathNoInsurance.length); i++) {
+        if (pathWithInsurance[i].age < 60) {
+          // Before preservation age, super with insurance should be lower
+          expect(pathWithInsurance[i].super).toBeLessThan(pathNoInsurance[i].super);
+        }
+      }
+    });
+
+    it('should tag phases correctly for age-banded spending', () => {
+      const path = buildDwzDepletionPath({
+        currentAge: 30,
+        retirementAge: 50,
+        lifeExpectancy: 85,
+        sustainableAnnual: 60000,
+        bands: [
+          { startAge: 50, endAge: 60, multiplier: 1.1, name: 'go-go' },
+          { startAge: 60, endAge: 75, multiplier: 1.0, name: 'slow-go' },
+          { startAge: 75, endAge: 85, multiplier: 0.85, name: 'no-go' }
+        ],
+        preservationAge: 60,
+        realReturn: 0.05,
+        fees: 0,
+        insurancePremium: 0,
+        bequest: 0,
+        startBalances: { outside: 500000, super: 800000 }
+      });
+
+      // Check phase tagging
+      const age55Point = path.find(p => p.age === 55);
+      expect(age55Point?.phase).toBe('go-go');
+
+      const age65Point = path.find(p => p.age === 65);
+      expect(age65Point?.phase).toBe('slow-go');
+
+      const age80Point = path.find(p => p.age === 80);
+      expect(age80Point?.phase).toBe('no-go');
+    });
+  });
+
+  describe('Decision selector integration', () => {
+    it('should include depletion path in DWZ bundle', () => {
+      const state = {
+        currentAge: 35,
+        lifeExpectancy: 85,
+        currentSavings: 200000,
+        currentSuper: 300000,
+        annualIncome: 100000,
+        annualExpenses: 60000,
+        expectedReturn: 7.0,
+        inflationRate: 2.5,
+        planningAs: 'single',
+        ageBandsEnabled: true
+      };
+
+      const decision = decisionFromState(state, auRules);
+
+      // Should have a depletion path
+      expect(decision.dwz?.path).toBeDefined();
+      expect(Array.isArray(decision.dwz.path)).toBe(true);
+      
+      if (decision.dwz?.path?.length > 0) {
+        // Path should start at current age
+        expect(decision.dwz.path[0].age).toBe(state.currentAge);
+        
+        // Path should end at life expectancy
+        const lastPoint = decision.dwz.path[decision.dwz.path.length - 1];
+        expect(lastPoint.age).toBe(state.lifeExpectancy);
+        
+        // Should have required fields
+        const firstPoint = decision.dwz.path[0];
+        expect(firstPoint).toHaveProperty('outside');
+        expect(firstPoint).toHaveProperty('super');
+        expect(firstPoint).toHaveProperty('total');
+        expect(firstPoint).toHaveProperty('phase');
+        expect(firstPoint).toHaveProperty('spend');
+      }
+    });
+
+    it('should show declining wealth when viable', () => {
+      const state = {
+        currentAge: 45,
+        lifeExpectancy: 85,
+        currentSavings: 500000,
+        currentSuper: 800000,
+        annualIncome: 120000,
+        annualExpenses: 70000,
+        expectedReturn: 7.0,
+        inflationRate: 2.5,
+        planningAs: 'single',
+        ageBandsEnabled: false // Flat spending for simplicity
+      };
+
+      const decision = decisionFromState(state, auRules);
+
+      if (decision.dwz?.isViable && decision.dwz?.path?.length > 0) {
+        // Find retirement point
+        const retirementAge = decision.dwz.earliestViableAge || 60;
+        const retirementIndex = decision.dwz.path.findIndex(p => p.age >= retirementAge);
+        
+        if (retirementIndex > 0) {
+          // After retirement, wealth should generally decline (allowing for some growth in early years)
+          const postRetirementPath = decision.dwz.path.slice(retirementIndex);
+          
+          // Check that wealth eventually declines
+          const midPoint = postRetirementPath[Math.floor(postRetirementPath.length / 2)];
+          const endPoint = postRetirementPath[postRetirementPath.length - 1];
+          
+          expect(endPoint.total).toBeLessThan(midPoint.total);
+        }
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Why
Banner, Bridge, and Chart were using different spending assumptions (and some stale memos), causing contradictions and scale-dependent behaviour after large balance changes. Users would see green banners with red bridge status, or charts growing to $20M+ instead of depleting to ~$0.

## What
- Single DWZ bundle in `decision.dwz` with `sustainableAnnual (S_base)`, `bands`, `earliestViableAge`, `path`, and `bridge`.
- Depletion path built from `S_base × bandMultiplierAt(age)` in real dollars with premiums before returns.
- Bridge needs computed by summing pre-60 schedule using `computeBridgeFromSchedule()` (epsilon clamp kept).
- Chart, Banner, and Bridge now read from the same unified bundle.
- Added helper functions: `bandMultiplierAt()`, `annualSpendFor()`, `computeBridgeFromSchedule()`.

## Tests
- **Scale invariance**: 10× balance changes maintain proper depletion behavior
- **Banner-Bridge consistency**: No more green banner + red bridge contradictions  
- **Helper function validation**: Core spending and bridge calculations tested
- **Insurance integration**: Premiums applied before returns and reflected in path

## Outcome
- **Eliminates contradictions**: No more green banner with red bridge status
- **Scale-invariant depletion**: Chart tapers to ≈ bequest at life expectancy regardless of balance magnitude
- **Unified spending**: All surfaces present one coherent DWZ plan using the same schedule
- **Real dollar consistency**: All calculations maintain purchasing power accuracy

## Manual Testing
Available at http://localhost:5174:
1. Default inputs → verify chart tapers to ~$0, banner/bridge agree
2. 10× balances → earliest age shifts appropriately, chart still tapers, no contradictions
3. Toggle age-bands → pre-60 spending changes, bridge reflects actual schedule
4. Add insurance → super trajectory dips consistently across all components

🧪 **All tests passing**: 10 new consistency tests + existing DWZ/depletion tests green
📦 **Build verified**: Production build succeeds without errors