### PR TITLE
Fix optimizer tie-breaker: use retirement boundary wealth

### DIFF
--- a/packages/dwz-core/__tests__/dwz-depletion-path.test.js
+++ b/packages/dwz-core/__tests__/dwz-depletion-path.test.js
@@ -1,0 +1,44 @@
+import { describe, test, expect } from 'vitest';
+import { optimizeSavingsSplitForPlan } from '../src/optimizer/savingsSplit.ts';
+
+describe('dwz depletion path via solver+optimizer', () => {
+  test('tie-breaker for consistent plan uses tax-aware boundary wealth', () => {
+    const baseInput = {
+      currentAge: 45,
+      preserveAge: 60,
+      lifeExp: 90,
+      outside0: 500000,
+      super0: 200000,
+      realReturn: 0.059,
+      annualSavings: 50000,
+      bands: [
+        { endAgeIncl: 74, multiplier: 1.0 },
+        { endAgeIncl: 199, multiplier: 0.85 }
+      ],
+      bequest: 0
+    };
+
+    const policy = {
+      capPerPerson: 30000,
+      eligiblePeople: 1,
+      contribTaxRate: 0.15,
+      outsideTaxRate: 0.32,
+      maxPct: 1.0
+    };
+
+    const opts = {
+      gridPoints: 11,
+      refineIters: 1,
+      window: 0.10,
+      ageToleranceYears: 0.5,
+      preferSuperTieBreak: true
+    };
+
+    const result = optimizeSavingsSplitForPlan(baseInput, 75000, policy, opts);
+    
+    // With salary sacrifice advantage (32% MTR vs 15% super tax) and tie-breaker,
+    // we should prefer some super allocation over 0% when ages are close
+    expect(result.recommendedPct).toBeGreaterThan(0.3);
+    expect(result.earliestAge).toBeGreaterThanOrEqual(45);  // Verify feasible result
+  });
+});

--- a/packages/dwz-core/src/optimizer/savingsSplit.ts
+++ b/packages/dwz-core/src/optimizer/savingsSplit.ts
@@ -268,7 +268,7 @@ export function optimizeSavingsSplitForPlan(
     memo.forEach((v, k) => {
       if (v.earliestAge != null && (v.earliestAge as number) <= targetAge + tol + 1e-9) cands.push(k);
     });
-    // For each candidate, evaluate total wealth at the start of retirement at targetAge
+    // For each candidate, evaluate total wealth at the retirement boundary (last accumulation point)
     let bestWealth = -Infinity;
     for (const p of cands) {
       const at = accumulateUntil({
@@ -281,7 +281,7 @@ export function optimizeSavingsSplitForPlan(
           outsideTaxRate: policy.outsideTaxRate,
           mode: 'grossDeferral'
         }
-      }, targetAge);
+      }, targetAge - 1);  // Use retirement boundary (last accumulation point)
       const w = at.outside + at.super;
       if (w > bestWealth) { bestWealth = w; chosenPct = p; }
     }


### PR DESCRIPTION
## Summary
- Fix tie-breaker wealth calculation to use retirement boundary (targetAge - 1) instead of after first retirement year
- Add regression test to verify tax-aware tie-breaker behavior with salary sacrifice advantage

## Details
The tie-breaker in `optimizeSavingsSplitForPlan` was measuring wealth at the wrong point - after the first retirement year instead of at the retirement boundary. This affected the secondary objective of maximizing wealth when choosing between splits with equivalent earliest retirement ages.

## Changes
1. **Fixed boundary calculation**: Changed `accumulateUntil(input, targetAge)` to `accumulateUntil(input, targetAge - 1)` to measure wealth at the last accumulation point rather than after spending begins
2. **Added regression test**: Verifies tie-breaker prefers super allocation when tax advantage exists and ages are within tolerance

## Test Results
- All existing tests pass ✅
- New regression test passes ✅
- Build successful ✅

🤖 Generated with [Claude Code](https://claude.ai/code)