### PR TITLE
Fix: robust WealthChart rendering (stable series keys + fixed height)

### DIFF
--- a/apps/dwz-v2/src/App.tsx
+++ b/apps/dwz-v2/src/App.tsx
@@ -408,8 +408,11 @@ export default function App() {
         </>
       )}
 
-      {/* Show chart only when plan exists, is achievable, AND we have solve data */}
-      {planSpend && planFirstData && planFirstData.earliestAge !== null && data && data.path && data.path.length > 1 && (
+      {/* Render chart when we have a plan, a finite earliest age, and a computed path */}
+      {planSpend != null
+        && planFirstData?.earliestAge != null
+        && Number.isFinite(planFirstData.earliestAge)
+        && data?.path?.length > 1 && (
         <WealthChart 
           path={data.path} 
           lifeExp={household.lifeExp}


### PR DESCRIPTION
## Summary
Maps PathPoint→Chart rows with stable accumulation/retirement/bridge keys, adds fixed ResponsiveContainer height, and simplifies chart gating for consistent rendering.

## Problem Solved
Chart was sometimes blank even when plan was viable because:
- Recharts expected consistent series keys on all data rows
- Original chart used `outside`, `superBal`, `total` fields that weren't always present/consistent  
- Height wasn't explicitly set on ResponsiveContainer
- Multiple gating conditions could create "green banner but no chart" races

## Changes
1. **Canonical data transformation**: Maps PathPoint to ChartRow with stable keys:
   - `accumulation`: total wealth during accumulation phase (null otherwise)
   - `retirement`: total wealth during retirement phase (null otherwise) 
   - `bridge`: total wealth during bridge phase (null otherwise)

2. **Fixed ResponsiveContainer**: Explicit 360px height prevents zero-height rendering

3. **Simplified chart gating**: Single consistent check in App.tsx:
   - Plan exists (`planSpend != null`)
   - Earliest age is finite (`Number.isFinite(planFirstData.earliestAge)`)
   - Path data exists (`data?.path?.length > 1`)

4. **Enhanced visual features**:
   - Bridge period shading with reduced opacity  
   - Retirement age marker with dashed line
   - Y-axis bounds with padding for better visibility
   - Legend and improved tooltips

## Test Results
- Chart renders consistently when plan is viable ✅
- Fixed height prevents layout issues ✅  
- Bridge shading and retirement markers work correctly ✅
- No math changes to solver logic ✅

🤖 Generated with [Claude Code](https://claude.ai/code)