### PR TITLE
feat(ui): ATO rates by FY (no overrides)

### DIFF
--- a/apps/dwz-v2/src/App.tsx
+++ b/apps/dwz-v2/src/App.tsx
@@ -4,6 +4,7 @@ import { useDecision } from "./lib/useDecision";
 import { useSavingsSplitOptimizer } from "./lib/useSavingsSplitOptimizer";
 import { useSavingsSplitForPlan } from "./lib/useSavingsSplitForPlan";
 import { usePlanFirstSolver } from "./lib/usePlanFirstSolver";
+import { useConcessionalCap, useATORates } from "./lib/useATORates";
 import { auMoney0 } from "./lib/format";
 import WealthChart from "./components/WealthChart";
 import SensitivityChart from "./components/SensitivityChart";
@@ -27,7 +28,8 @@ export default function App() {
   // Savings split optimization
   const [autoOptimize, setAutoOptimize] = useState(true);
   const [manualSplitPct, setManualSplitPct] = useState(0.5);
-  const [capPerPerson, setCapPerPerson] = useState(30000);
+  const capPerPerson = useConcessionalCap(); // ATO-derived, no user override
+  const atoRates = useATORates(); // For displaying current FY info
   const [eligiblePeople, setEligiblePeople] = useState(2);
   const [outsideTaxRate, setOutsideTaxRate] = useState(0.32); // default 32% including Medicare
   const [preferSuperTieBreak, setPreferSuperTieBreak] = useState(true);
@@ -287,13 +289,12 @@ export default function App() {
             )}
           </div>
           <div>
-            <label>Concessional cap per person: 
-              <input 
-                type="number" 
-                value={capPerPerson} 
-                onChange={e => setCapPerPerson(+e.target.value)}
-              />
-            </label><br/>
+            <div style={{ marginBottom: 8 }}>
+              <span style={{ color: '#666', fontSize: '14px' }}>
+                Concessional cap per person (ATO FY {atoRates.financialYear}): 
+                <strong style={{ color: '#000' }}> {auMoney0(capPerPerson)}</strong>
+              </span>
+            </div>
             <label>Eligible people: 
               <select value={eligiblePeople} onChange={e => setEligiblePeople(+e.target.value)}>
                 <option value={1}>1 (single)</option>

--- a/apps/dwz-v2/src/lib/auRates.ts
+++ b/apps/dwz-v2/src/lib/auRates.ts
@@ -1,0 +1,49 @@
+export type FinancialYear = '2024-25' | '2025-26';
+type Bracket = { upTo: number | null; rate: number }; // rate excludes Medicare levy
+
+export const AU_RATES: Record<FinancialYear, {
+  concessionalCap: number;
+  sgRate: number;
+  taxBrackets: Bracket[];
+}> = {
+  '2024-25': {
+    concessionalCap: 30_000,
+    sgRate: 0.115,
+    taxBrackets: [
+      { upTo: 18_200, rate: 0.00 },
+      { upTo: 45_000, rate: 0.16 },
+      { upTo: 135_000, rate: 0.30 },
+      { upTo: 190_000, rate: 0.37 },
+      { upTo: null, rate: 0.45 },
+    ],
+  },
+  '2025-26': {
+    concessionalCap: 30_000,
+    sgRate: 0.12,
+    taxBrackets: [
+      { upTo: 18_200, rate: 0.00 },
+      { upTo: 45_000, rate: 0.16 },
+      { upTo: 135_000, rate: 0.30 },
+      { upTo: 190_000, rate: 0.37 },
+      { upTo: null, rate: 0.45 },
+    ],
+  },
+};
+
+/** Determine AU financial year in Australia/Melbourne time. */
+export function currentFYNowMelbourne(d = new Date()): FinancialYear {
+  // FY rolls on 1 July; ensure we compute in Melbourne time.
+  const fmt = new Intl.DateTimeFormat('en-AU', { timeZone: 'Australia/Melbourne', year: 'numeric', month: 'numeric' });
+  const parts = Object.fromEntries(fmt.formatToParts(d).map(p => [p.type, p.value]));
+  const year = Number(parts.year);
+  const month = Number(parts.month); // 1..12
+  const yStart = month >= 7 ? year : year - 1;
+  const label = `${yStart}-${(yStart + 1).toString().slice(-2)}` as FinancialYear; // e.g., 2025-26
+  return (label in AU_RATES ? label : '2024-25');
+}
+
+export function getAuDefaults(): { fy: FinancialYear; cap: number; sg: number; brackets: Bracket[] } {
+  const fy = currentFYNowMelbourne();
+  const r = AU_RATES[fy];
+  return { fy, cap: r.concessionalCap, sg: r.sgRate, brackets: r.taxBrackets };
+}

--- a/apps/dwz-v2/src/lib/useATORates.ts
+++ b/apps/dwz-v2/src/lib/useATORates.ts
@@ -1,0 +1,22 @@
+import { useMemo } from 'react';
+import { getAuDefaults, type FinancialYear } from './auRates';
+
+export function useATORates() {
+  return useMemo(() => {
+    const { fy, cap, sg, brackets } = getAuDefaults();
+    return {
+      financialYear: fy,
+      concessionalCap: cap,
+      superGuaranteeRate: sg,
+      taxBrackets: brackets
+    };
+  }, []); // No dependencies - only changes with date/time
+}
+
+export function useConcessionalCap(): number {
+  return useATORates().concessionalCap;
+}
+
+export function useDefaultSGRate(): number {
+  return useATORates().superGuaranteeRate;
+}


### PR DESCRIPTION
## Summary
Auto-picks concessional cap and SG rate from ATO tables by financial year (Australia/Melbourne timezone). Removes user overrides for these ATO-controlled values.

## Key Changes
- **ATO Tables**: Added `auRates.ts` with official cap/SG rates by FY
- **Auto-Detection**: Uses Australia/Melbourne time to determine current financial year
- **UI Update**: Replaced cap input with read-only ATO display showing FY and current values
- **React Integration**: `useConcessionalCap` hook replaces manual cap state

## ATO Sources & Values
- **Concessional cap**: A$30,000 (FY 2024-25 & 2025-26) - [ATO Contributions caps](https://www.ato.gov.au/tax-rates-and-codes/key-superannuation-rates-and-thresholds/contributions-caps)
- **Super Guarantee**: 11.5% (FY 2024-25) → 12.0% (FY 2025-26) - [ATO SG rate increase](https://www.ato.gov.au/businesses-and-organisations/small-business-newsroom/the-final-sg-rate-increase-is-coming-on-1-july)
- **Tax brackets**: Stage-3 schedule (FY 2024-25+) for future MTR helper - [ATO Tax rates](https://www.ato.gov.au/tax-rates-and-codes/tax-rates-australian-residents)

## Testing
- Build ✅ (vite build successful)
- Core tests ✅ (42/42 pass)
- Dev server ✅ (running on localhost:5174)
- FY detection works for current date (2025-08-29 → FY 2025-26)

🤖 Generated with [Claude Code](https://claude.ai/code)