### PR TITLE
feat(ui): Person Card panels — General info, Assets, Super settings

### DIFF
--- a/apps/dwz-v2/src/components/Panel.tsx
+++ b/apps/dwz-v2/src/components/Panel.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+
+export default function Panel({
+  title,
+  subtitle,
+  children,
+  className = '',
+}: {
+  title: string;
+  subtitle?: React.ReactNode;
+  children: React.ReactNode;
+  className?: string;
+}) {
+  return (
+    <section className={`rounded-2xl border bg-white/60 p-3 md:p-4 ${className}`}>
+      <header className="mb-3">
+        <div className="text-sm font-semibold">{title}</div>
+        {subtitle && <div className="text-xs text-gray-500 mt-0.5">{subtitle}</div>}
+      </header>
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+        {children}
+      </div>
+    </section>
+  );
+}

--- a/apps/dwz-v2/src/components/PersonCard.tsx
+++ b/apps/dwz-v2/src/components/PersonCard.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import Panel from './Panel';
 import PersonSuperSettings from './PersonSuperSettings';
 
 interface PersonCardProps {
@@ -81,76 +82,75 @@ export default function PersonCard({
     fontFamily: 'inherit'
   };
 
-  const comingSoonStyle: React.CSSProperties = {
-    marginTop: 16
-  };
-
-  const detailsStyle: React.CSSProperties = {
-    border: '1px solid #e5e7eb',
-    borderRadius: 6,
-    padding: '8px 12px',
-    backgroundColor: '#f9fafb'
-  };
-
-  const summaryStyle: React.CSSProperties = {
-    cursor: 'pointer',
-    fontSize: 13,
-    fontWeight: 500,
-    color: '#6b7280',
-    padding: '4px 0'
-  };
-
-  const placeholderStyle: React.CSSProperties = {
-    fontSize: 12,
-    color: '#9ca3af',
-    marginTop: 8,
-    lineHeight: 1.4
-  };
 
   return (
-    <div style={cardStyle}>
+    <div style={cardStyle} className="space-y-4">
       <h3 style={titleStyle}>{title}</h3>
-      
-      <label style={labelStyle}>
-        Age
-        <input 
-          type="number" 
-          value={age} 
-          onChange={e => onAgeChange(+e.target.value)}
-          style={inputStyle}
-        />
-      </label>
 
-      <label style={labelStyle}>
-        Income
-        <input 
-          type="number" 
-          value={income} 
-          onChange={e => onIncomeChange(+e.target.value)}
-          style={inputStyle}
-        />
-      </label>
+      {/* 1) General info */}
+      <Panel
+        title="General info"
+        subtitle="Your age and income. Tax & Benefits panel sits here (coming soon)."
+      >
+        <div className="col-span-1">
+          <label style={labelStyle}>
+            Age
+            <input 
+              type="number" 
+              value={age} 
+              onChange={e => onAgeChange(+e.target.value)}
+              style={inputStyle}
+            />
+          </label>
+        </div>
+        <div className="col-span-1">
+          <label style={labelStyle}>
+            Income
+            <input 
+              type="number" 
+              value={income} 
+              onChange={e => onIncomeChange(+e.target.value)}
+              style={inputStyle}
+            />
+          </label>
+        </div>
+        <div className="col-span-2">
+          <div className="mt-1 text-xs text-gray-500 border rounded px-2 py-1 bg-gray-50">
+            Tax &amp; Benefits panel (coming soon)
+          </div>
+        </div>
+      </Panel>
 
-      <label style={labelStyle}>
-        Outside
-        <input 
-          type="number" 
-          value={outside} 
-          onChange={e => onOutsideChange(+e.target.value)}
-          style={inputStyle}
-        />
-      </label>
+      {/* 2) Assets */}
+      <Panel
+        title="Assets"
+        subtitle="Starting balances. Extendable later for other assets / lump sums."
+      >
+        <div className="col-span-1">
+          <label style={labelStyle}>
+            Outside
+            <input 
+              type="number" 
+              value={outside} 
+              onChange={e => onOutsideChange(+e.target.value)}
+              style={inputStyle}
+            />
+          </label>
+        </div>
+        <div className="col-span-1">
+          <label style={labelStyle}>
+            Super
+            <input 
+              type="number" 
+              value={superBalance} 
+              onChange={e => onSuperChange(+e.target.value)}
+              style={inputStyle}
+            />
+          </label>
+        </div>
+      </Panel>
 
-      <label style={labelStyle}>
-        Super
-        <input 
-          type="number" 
-          value={superBalance} 
-          onChange={e => onSuperChange(+e.target.value)}
-          style={inputStyle}
-        />
-      </label>
-
+      {/* 3) Super settings (already implemented) */}
       <PersonSuperSettings
         index={index}
         salary={salary}
@@ -164,20 +164,6 @@ export default function PersonCard({
         annualSavings={annualSavings}
         allRemainingCaps={allRemainingCaps}
       />
-
-      <div style={comingSoonStyle}>
-        <details style={detailsStyle}>
-          <summary style={summaryStyle}>Tax & Benefits (coming soon)</summary>
-          <div style={placeholderStyle}>
-            <div>• HECS/HELP debt: Not yet configured</div>
-            <div>• Private health insurance: Not yet configured</div>
-            <div>• Insurance in super: Not yet configured</div>
-            <div style={{ marginTop: 8, fontStyle: 'italic' }}>
-              These will enable more precise tax calculations and optimization in future updates.
-            </div>
-          </div>
-        </details>
-      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
• Restructures PersonCard into three organized panels: **General info**, **Assets**, **Super settings**
• Adds reusable Panel component for consistent styling and layout
• Preserves all existing functionality and state management - pure UI refactor

## What/Why
Improves clarity and organization of person card inputs. Sets up space for future Tax & Benefits panel. Isolates Assets section for future asset types & lump sums.

## Changes
• **Added** `Panel.tsx` - shared presentational wrapper component
• **Modified** `PersonCard.tsx` - restructured into three logical panels
• No behavioural changes - all inputs and state management preserved

## Risk
Low (markup/styling only). No engine or core math changes.

## Rollback
Revert `PersonCard.tsx` and delete `Panel.tsx`.

🤖 Generated with [Claude Code](https://claude.ai/code)