### PR TITLE
feat(ui): Compact chips + inline help for person top panels

### DIFF
--- a/apps/dwz-v2/src/components/InfoChips.tsx
+++ b/apps/dwz-v2/src/components/InfoChips.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+export default function InfoChips({ items }: { items: string[] }) {
+  return (
+    <div className="flex flex-wrap gap-1.5 mt-2">
+      {items.map((t, i) => (
+        <span
+          key={i}
+          className="inline-flex items-center rounded-full border bg-gray-50 px-2 py-0.5 text-[11px] text-gray-700"
+        >
+          {t}
+        </span>
+      ))}
+    </div>
+  );
+}

--- a/apps/dwz-v2/src/components/InfoTip.tsx
+++ b/apps/dwz-v2/src/components/InfoTip.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+
+export default function InfoTip({ children }: { children: React.ReactNode }) {
+  return (
+    <details className="inline-block ml-2 align-middle">
+      <summary className="cursor-pointer text-xs text-blue-700 hover:underline select-none">
+        Learn more
+      </summary>
+      <div className="mt-1 text-xs text-gray-700 bg-white border rounded p-2 shadow-sm max-w-prose">
+        {children}
+      </div>
+    </details>
+  );
+}

--- a/apps/dwz-v2/src/components/Panel.tsx
+++ b/apps/dwz-v2/src/components/Panel.tsx
@@ -1,9 +1,13 @@
 import React from 'react';
+import InfoChips from './InfoChips';
+import InfoTip from './InfoTip';
 
 export default function Panel({
   title,
   subtitle,
   definition,
+  chips,
+  help,
   children,
   className = '',
 }: {
@@ -11,6 +15,10 @@ export default function Panel({
   subtitle?: React.ReactNode;
   /** Optional muted definition/help block shown below subtitle */
   definition?: React.ReactNode;
+  /** Compact badges shown under the header */
+  chips?: string[];
+  /** Extra help content rendered in a tiny disclosure ("Learn more") */
+  help?: React.ReactNode;
   children: React.ReactNode;
   className?: string;
 }) {
@@ -24,6 +32,8 @@ export default function Panel({
             {definition}
           </div>
         )}
+        {chips && chips.length > 0 && <InfoChips items={chips} />}
+        {help && <InfoTip>{help}</InfoTip>}
       </header>
       <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
         {children}

--- a/apps/dwz-v2/src/components/Panel.tsx
+++ b/apps/dwz-v2/src/components/Panel.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+
+export default function Panel({
+  title,
+  subtitle,
+  children,
+  className = '',
+}: {
+  title: string;
+  subtitle?: React.ReactNode;
+  children: React.ReactNode;
+  className?: string;
+}) {
+  return (
+    <section className={`rounded-2xl border bg-white/60 p-3 md:p-4 ${className}`}>
+      <header className="mb-3">
+        <div className="text-sm font-semibold">{title}</div>
+        {subtitle && <div className="text-xs text-gray-500 mt-0.5">{subtitle}</div>}
+      </header>
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+        {children}
+      </div>
+    </section>
+  );
+}

--- a/apps/dwz-v2/src/components/Panel.tsx
+++ b/apps/dwz-v2/src/components/Panel.tsx
@@ -3,11 +3,14 @@ import React from 'react';
 export default function Panel({
   title,
   subtitle,
+  definition,
   children,
   className = '',
 }: {
   title: string;
   subtitle?: React.ReactNode;
+  /** Optional muted definition/help block shown below subtitle */
+  definition?: React.ReactNode;
   children: React.ReactNode;
   className?: string;
 }) {
@@ -16,6 +19,11 @@ export default function Panel({
       <header className="mb-3">
         <div className="text-sm font-semibold">{title}</div>
         {subtitle && <div className="text-xs text-gray-500 mt-0.5">{subtitle}</div>}
+        {definition && (
+          <div className="mt-2 text-xs text-gray-700 bg-gray-50/80 border border-gray-200 rounded px-2 py-1.5">
+            {definition}
+          </div>
+        )}
       </header>
       <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
         {children}

--- a/apps/dwz-v2/src/components/PersonCard.tsx
+++ b/apps/dwz-v2/src/components/PersonCard.tsx
@@ -91,10 +91,11 @@ export default function PersonCard({
       <Panel
         title="General info"
         subtitle="Your age and income."
-        definition={
+        chips={['today\'s dollars', 'end-of-year ages', 'Tax & Benefits soon']}
+        help={
           <span>
-            All figures are in <strong>today's dollars</strong>. Ages update at end of year (spend → grow → advance age).
-            A dedicated <em>Tax &amp; Benefits</em> panel (HECS/HELP, rebates, MLS) will sit here soon.
+            Figures are net real (inflation-adjusted). We advance age at end of year after spend → returns/fees. 
+            A Tax &amp; Benefits panel (e.g., HECS/HELP, rebates, MLS) will live here.
           </span>
         }
       >
@@ -126,10 +127,12 @@ export default function PersonCard({
       <Panel
         title="Assets"
         subtitle="Starting balances"
-        definition={
+        chips={['outside vs super', 'no contributions after FIRE', 'more assets soon']}
+        help={
           <span>
-            Balances are tracked as <strong>outside</strong> vs <strong>super</strong>. No contributions occur after FIRE
-            (DWZ invariant). We'll add other asset types &amp; lump sums here in a future update.
+            We track two buckets for withdrawals and tax: outside and super. 
+            After retirement (FIRE), contributions stop by design (DWZ). 
+            We'll add other assets and one-off lump sums here later.
           </span>
         }
       >

--- a/apps/dwz-v2/src/components/PersonCard.tsx
+++ b/apps/dwz-v2/src/components/PersonCard.tsx
@@ -90,7 +90,13 @@ export default function PersonCard({
       {/* 1) General info */}
       <Panel
         title="General info"
-        subtitle="Your age and income. Tax & Benefits panel sits here (coming soon)."
+        subtitle="Your age and income."
+        definition={
+          <span>
+            All figures are in <strong>today's dollars</strong>. Ages update at end of year (spend → grow → advance age).
+            A dedicated <em>Tax &amp; Benefits</em> panel (HECS/HELP, rebates, MLS) will sit here soon.
+          </span>
+        }
       >
         <div className="col-span-1">
           <label style={labelStyle}>
@@ -114,17 +120,18 @@ export default function PersonCard({
             />
           </label>
         </div>
-        <div className="col-span-2">
-          <div className="mt-1 text-xs text-gray-500 border rounded px-2 py-1 bg-gray-50">
-            Tax &amp; Benefits panel (coming soon)
-          </div>
-        </div>
       </Panel>
 
       {/* 2) Assets */}
       <Panel
         title="Assets"
-        subtitle="Starting balances. Extendable later for other assets / lump sums."
+        subtitle="Starting balances"
+        definition={
+          <span>
+            Balances are tracked as <strong>outside</strong> vs <strong>super</strong>. No contributions occur after FIRE
+            (DWZ invariant). We'll add other asset types &amp; lump sums here in a future update.
+          </span>
+        }
       >
         <div className="col-span-1">
           <label style={labelStyle}>

--- a/apps/dwz-v2/src/components/PersonCard.tsx
+++ b/apps/dwz-v2/src/components/PersonCard.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import Panel from './Panel';
 import PersonSuperSettings from './PersonSuperSettings';
 
 interface PersonCardProps {
@@ -81,76 +82,75 @@ export default function PersonCard({
     fontFamily: 'inherit'
   };
 
-  const comingSoonStyle: React.CSSProperties = {
-    marginTop: 16
-  };
-
-  const detailsStyle: React.CSSProperties = {
-    border: '1px solid #e5e7eb',
-    borderRadius: 6,
-    padding: '8px 12px',
-    backgroundColor: '#f9fafb'
-  };
-
-  const summaryStyle: React.CSSProperties = {
-    cursor: 'pointer',
-    fontSize: 13,
-    fontWeight: 500,
-    color: '#6b7280',
-    padding: '4px 0'
-  };
-
-  const placeholderStyle: React.CSSProperties = {
-    fontSize: 12,
-    color: '#9ca3af',
-    marginTop: 8,
-    lineHeight: 1.4
-  };
 
   return (
-    <div style={cardStyle}>
+    <div style={cardStyle} className="space-y-4">
       <h3 style={titleStyle}>{title}</h3>
-      
-      <label style={labelStyle}>
-        Age
-        <input 
-          type="number" 
-          value={age} 
-          onChange={e => onAgeChange(+e.target.value)}
-          style={inputStyle}
-        />
-      </label>
 
-      <label style={labelStyle}>
-        Income
-        <input 
-          type="number" 
-          value={income} 
-          onChange={e => onIncomeChange(+e.target.value)}
-          style={inputStyle}
-        />
-      </label>
+      {/* 1) General info */}
+      <Panel
+        title="General info"
+        subtitle="Your age and income. Tax & Benefits panel sits here (coming soon)."
+      >
+        <div className="col-span-1">
+          <label style={labelStyle}>
+            Age
+            <input 
+              type="number" 
+              value={age} 
+              onChange={e => onAgeChange(+e.target.value)}
+              style={inputStyle}
+            />
+          </label>
+        </div>
+        <div className="col-span-1">
+          <label style={labelStyle}>
+            Income
+            <input 
+              type="number" 
+              value={income} 
+              onChange={e => onIncomeChange(+e.target.value)}
+              style={inputStyle}
+            />
+          </label>
+        </div>
+        <div className="col-span-2">
+          <div className="mt-1 text-xs text-gray-500 border rounded px-2 py-1 bg-gray-50">
+            Tax &amp; Benefits panel (coming soon)
+          </div>
+        </div>
+      </Panel>
 
-      <label style={labelStyle}>
-        Outside
-        <input 
-          type="number" 
-          value={outside} 
-          onChange={e => onOutsideChange(+e.target.value)}
-          style={inputStyle}
-        />
-      </label>
+      {/* 2) Assets */}
+      <Panel
+        title="Assets"
+        subtitle="Starting balances. Extendable later for other assets / lump sums."
+      >
+        <div className="col-span-1">
+          <label style={labelStyle}>
+            Outside
+            <input 
+              type="number" 
+              value={outside} 
+              onChange={e => onOutsideChange(+e.target.value)}
+              style={inputStyle}
+            />
+          </label>
+        </div>
+        <div className="col-span-1">
+          <label style={labelStyle}>
+            Super
+            <input 
+              type="number" 
+              value={superBalance} 
+              onChange={e => onSuperChange(+e.target.value)}
+              style={inputStyle}
+            />
+          </label>
+        </div>
+      </Panel>
 
-      <label style={labelStyle}>
-        Super
-        <input 
-          type="number" 
-          value={superBalance} 
-          onChange={e => onSuperChange(+e.target.value)}
-          style={inputStyle}
-        />
-      </label>
-
+      {/* 3) Super settings (already implemented) */}
       <PersonSuperSettings
         index={index}
         salary={salary}
@@ -164,20 +164,6 @@ export default function PersonCard({
         annualSavings={annualSavings}
         allRemainingCaps={allRemainingCaps}
       />
-
-      <div style={comingSoonStyle}>
-        <details style={detailsStyle}>
-          <summary style={summaryStyle}>Tax & Benefits (coming soon)</summary>
-          <div style={placeholderStyle}>
-            <div>• HECS/HELP debt: Not yet configured</div>
-            <div>• Private health insurance: Not yet configured</div>
-            <div>• Insurance in super: Not yet configured</div>
-            <div style={{ marginTop: 8, fontStyle: 'italic' }}>
-              These will enable more precise tax calculations and optimization in future updates.
-            </div>
-          </div>
-        </details>
-      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
• Replaces bulky definition paragraphs with concise **chips** and **"Learn more"** inline tips
• Adds `InfoChips` component for compact badge display
• Adds `InfoTip` component for collapsible help content 
• Makes top panels feel as crisp and scannable as lower sections

## What/Why
The top panels previously had long paragraph definitions that felt heavy compared to the clean lower panels. This change provides the same helpful context in a more digestible format with compact chips for key concepts and detailed explanations available on-demand.

## Changes
• **Added** `InfoTip.tsx` - collapsible "Learn more" disclosure component
• **Added** `InfoChips.tsx` - compact badge/chip display component
• **Enhanced** `Panel.tsx` - added `chips` and `help` props alongside existing `definition`
• **Updated** `PersonCard.tsx` - replaced definition blocks with chips + help tips

## Key Improvements
• **General info**: 3 chips (`today's dollars`, `end-of-year ages`, `Tax & Benefits soon`)
• **Assets**: 3 chips (`outside vs super`, `no contributions after FIRE`, `more assets soon`)
• Detailed explanations moved to collapsible "Learn more" tips
• Cleaner visual hierarchy and better scannability

## Risk
Very low - UI-only changes, no functional or state modifications.

## Rollback
Revert all files to restore definition-based approach.

🤖 Generated with [Claude Code](https://claude.ai/code)